### PR TITLE
Fix link to `Ask a question` in `New issue`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/orgs/supabase/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop
     about: Request a new feature or example.
   - name: Ask a question
-    url: https://github.com/supabase/supabase/discussions/category_choices
+    url: https://github.com/orgs/supabase/discussions/categories/questions
     about: Ask questions and discuss with other community members.
   - name: Want to work with us?
     url: https://supabase.io/humans.txt

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/orgs/supabase/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop
     about: Request a new feature or example.
   - name: Ask a question
-    url: https://github.com/orgs/supabase/discussions/categories/questions
+    url: https://github.com/orgs/supabase/discussions/new/choose
     about: Ask questions and discuss with other community members.
   - name: Want to work with us?
     url: https://supabase.io/humans.txt


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix link in New issue

## What is the current behavior?

`Ask a question` link may be incorrect.

<img width="800" alt="Ask a question in New issue" src="https://github.com/user-attachments/assets/9f3a52e8-ff9a-4188-84b9-669446e8b3be">

For example, if you click on `Ask a question` at https://github.com/supabase/supabase/issues/new/choose, you will be directed to https://github.com/orgs/supabase/discussions/new/choose. The following message will appear:

<img width="800" alt="Post-transition message" src="https://github.com/user-attachments/assets/50431aba-9aab-444a-b189-26545b31290e">

## What is the new behavior?

If you click on `Ask a question` at https://github.com/supabase/supabase/issues/new/choose, the following notifications will no longer appear.

> Sorry, we didn't recognize that category! Please choose one of the following valid categories.

## Additional context

I am currently investigating a better issue templates, and the flow from `New issue` to `Discussions` was very helpful. Thanks!
